### PR TITLE
Disable ntru tests, for not experimental compilation. Coveralls tests back to 4x%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ option(OPTION_LEVEL_IS_PREVIEW "Enable the less tested code, that is not yet rec
 option(OPTION_LEVEL_IS_EXPERIMENT "Enable the experimental code, that has bugs" OFF)
 option(OPTION_LEVEL_IS_EXPERIMENT_DANGEROUS "Enable the most experimental code, that has bugs and vulnerabilities" OFF)
 
+option(COVERAGE "Enable coverage tests" ON)
+
 if(OPTION_LEVEL_IS_PREVIEW)
 	add_definitions(-DOPTION_LEVEL_IS_PREVIEW)
 endif()
@@ -63,9 +65,12 @@ target_link_libraries(ntrusign fftw3 m)
 link_directories( build_extra/ntru/.libs )
 include_directories( build_extra )
 
+if(COVERAGE)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -pedantic --coverage")
+else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -pedantic")
+endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -pedantic")
-# --coverage = enabling coverage
 set(CMAKE_CXX_BASE_FLAGS "${CMAKE_CXX_FLAGS}")
 
 

--- a/src/crypto/crypto_basic.cpp
+++ b/src/crypto/crypto_basic.cpp
@@ -118,11 +118,6 @@ t_hash_PRV Hash1_PRV( const t_hash_PRV & hash ) {
     return out_u_hash;
 }
 
-
-constexpr size_t Hash1_size() {
-	return 64;
-}
-
 t_hash Hash2( const t_hash & hash ) {
     t_hash hash_from_hash = Hash1(hash);
     for(auto &ch : hash_from_hash) { // negate all octets in it
@@ -143,10 +138,6 @@ t_hash_PRV Hash2_PRV( const t_hash_PRV & hash ) {
     const auto ret = Hash1_PRV(hash_from_hash);
     assert( ret.size() == Hash2_size() );
     return ret;
-}
-
-constexpr size_t Hash2_size() {
-	return 64;
 }
 
 // ==================================================================

--- a/src/crypto/crypto_basic.hpp
+++ b/src/crypto/crypto_basic.hpp
@@ -137,9 +137,9 @@ typedef std::string t_hash; ///< type of hash
 typedef sodiumpp::locked_string t_hash_PRV; ///< type of hash that contains a private secure data (e.g. is memlocked)
 
 t_hash Hash1( const t_hash & hash );
-constexpr size_t Hash1_size(); ///< returns size (in octets) of the output of Hash1 function
+constexpr size_t Hash1_size() { return 64; } ///< returns size (in octets) of the output of Hash1 function
 t_hash Hash2( const t_hash & hash );
-constexpr size_t Hash2_size(); ///< returns size (in octets) of the output of Hash1 function
+constexpr size_t Hash2_size() { return 64; } ///< returns size (in octets) of the output of Hash1 function
 
 t_hash_PRV Hash1_PRV( const t_hash_PRV & hash );
 t_hash_PRV Hash2_PRV( const t_hash_PRV & hash );

--- a/src/test/crypto.cpp
+++ b/src/test/crypto.cpp
@@ -163,6 +163,7 @@ TEST(crypto, bin_string_xor) {
 	EXPECT_EQ(true, size_diff_err);
 }
 
+#if OPTION_LEVEL_IS_EXPERIMENT
 TEST(crypto, ntru_sign) {
 	const std::string msg("message to sign");
 	int64 secretkey[PASS_N];
@@ -252,6 +253,7 @@ TEST(crypto, ntrupp_sign) {
 
 	EXPECT_TRUE(ntrupp::verify(signature, msg, keypair.second));
 }
+#endif
 
 TEST(crypto, multi_sign_ed25519) {
 
@@ -281,6 +283,7 @@ TEST(crypto, multi_sign_ed25519) {
 	});
 }
 
+#if OPTION_LEVEL_IS_EXPERIMENT
 TEST(crypto, multi_sign) {
 
 	antinet_crypto::c_multikeys_PAIR Alice;
@@ -313,8 +316,7 @@ TEST(crypto, multi_sign) {
 															Alice.read_pub());
 	});
 }
-
-
+#endif
 
 TEST(crypto, ipv6_hexdot) {
 	const size_t test_number = 10;
@@ -348,7 +350,9 @@ TEST(crypto, generate_unique_user_key) {
 	std::set<std::string> ipv6_hexdot;
 	for (size_t i = 0; i < number_of_test; ++i) {
 		c_multikeys_PAIR user_key;
+#if OPTION_LEVEL_IS_EXPERIMENT
 		user_key.generate(antinet_crypto::e_crypto_system_type_NTRU_sign,1);
+#endif
 		user_key.generate(antinet_crypto::e_crypto_system_type_Ed25519,1);
 		user_key.generate(antinet_crypto::e_crypto_system_type_X25519,1);
 		pubkeys.insert(user_key.get_serialize_bin_pubkey());
@@ -370,7 +374,9 @@ TEST(crypto, save_and_open_user_key) {
 	for (size_t i = 0; i < number_of_test; ++i) {
 		std::string tmp_filename_nr(tmp_filename + std::to_string(i));
 		c_multikeys_PAIR user_key;
+#if OPTION_LEVEL_IS_EXPERIMENT
 		user_key.generate(antinet_crypto::e_crypto_system_type_NTRU_sign,1);
+#endif
 		user_key.generate(antinet_crypto::e_crypto_system_type_Ed25519,1);
 		user_key.generate(antinet_crypto::e_crypto_system_type_X25519,1);
 
@@ -394,13 +400,15 @@ TEST(crypto, create_cryptolink) {
 	const size_t number_of_test = 1000;
 	for (size_t i = 0; i < number_of_test; ++i) {
 		g_dbg_level_set(160, "start test");
-		c_multikeys_PAIR keypairA;
-		keypairA.generate(e_crypto_system_type_Ed25519, 2);
-		keypairA.generate(e_crypto_system_type_NTRU_sign, 1);
-		c_multikeys_PAIR keypairB;
-		keypairB.generate(e_crypto_system_type_Ed25519, 2);
-		keypairB.generate(e_crypto_system_type_NTRU_sign, 1);
+		c_multikeys_PAIR keypairA, keypairB;
 
+		keypairA.generate(e_crypto_system_type_Ed25519, 2);
+		keypairB.generate(e_crypto_system_type_Ed25519, 2);
+
+#if OPTION_LEVEL_IS_EXPERIMENT
+		keypairA.generate(e_crypto_system_type_NTRU_sign, 1);
+		keypairB.generate(e_crypto_system_type_NTRU_sign, 1);
+#endif
 		c_multikeys_pub keypubA = keypairA.m_pub;
 		c_multikeys_pub keypubB = keypairB.m_pub;
 


### PR DESCRIPTION
To disable coverage:
$ cmake -DCOVERAGE=OFF . 