### PR TITLE
Restore mingw windows installer build deterministic

### DIFF
--- a/contrib/gitian-descriptors/main-build/galaxy-windows-script
+++ b/contrib/gitian-descriptors/main-build/galaxy-windows-script
@@ -112,6 +112,7 @@ echo "FAKETIME = ${FAKETIME}"
 WRAP_DIR="$HOME/wrapped"
 HOSTS="x86_64-w64-mingw32 i686-w64-mingw32" # related to $TARGET_ARCH
 COMPILERS="g++ gcc cpp g++-posix gcc-posix cpp-posix cc c++" # do we need "cc c++"? TODO
+NATIVE_COLPILATION_TOOLS="g++ gcc cpp cc c++ ar ranlib nm strip objcopy elfedit ld ld.bfd objdump readelf"
 
 ##  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
 CONFIGFLAGS=""
@@ -140,11 +141,11 @@ if test -n "$GBUILD_CACHE_ENABLED"; then
 fi
 
 function create_global_faketime_wrappers {
-for prog in ${FAKETIME_PROGS}; do
+for prog in ${FAKETIME_PROGS} ${NATIVE_COLPILATION_TOOLS}; do
 	outfile="${WRAP_DIR}/${prog}"
 	printf "\n%s\n" "WRAPPING (global): $outfile"
     echo '#!/bin/bash' > ${WRAP_DIR}/${prog}
-    echo "REAL=\`which -a ${prog} | grep -v ${WRAP_DIR}/${prog} | head -1\`" >> ${WRAP_DIR}/${prog}
+	echo "REAL=\"$(which -a ${prog})\"" >> ${WRAP_DIR}/${prog}
     echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${prog}
     echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${prog}
     echo "\$REAL \$@" >> $WRAP_DIR/${prog}
@@ -153,12 +154,12 @@ done
 }
 
 function create_per-host_faketime_wrappers {
-for i in $HOSTS; do
+for i in ${HOSTS}; do
     for prog in ${FAKETIME_HOST_PROGS}; do
 	outfile="${WRAP_DIR}/${i}-${prog}"
 	printf "\n%s\n" "WRAPPING (per-host): $outfile"
         echo '#!/bin/bash' > ${WRAP_DIR}/${i}-${prog}
-        echo "REAL=\`which -a ${i}-${prog} | grep -v ${WRAP_DIR}/${i}-${prog} | head -1\`" >> ${WRAP_DIR}/${i}-${prog}
+		echo "REAL=\"$(which -a ${i}-${prog})\"" >> ${WRAP_DIR}/${i}-${prog}
         echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${i}-${prog}
         echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${i}-${prog}
         echo "\$REAL \$@" >> $WRAP_DIR/${i}-${prog}
@@ -170,7 +171,7 @@ done
 function create_per-host_linker_wrapper {
 # This is only needed for trusty, as the mingw linker leaks a few bytes of
 # heap, causing non-determinism. See discussion in https://github.com/bitcoin/bitcoin/pull/6900
-for i in $HOSTS; do
+for i in ${HOSTS}; do
     mkdir -p ${WRAP_DIR}/${i}
     for prog in collect2; do
         echo '#!/bin/bash' > ${WRAP_DIR}/${i}/${prog}
@@ -181,7 +182,7 @@ for i in $HOSTS; do
     done
     for prog in ${COMPILERS}; do
         echo '#!/bin/bash' > ${WRAP_DIR}/${i}-${prog}
-        echo "REAL=\`which -a ${i}-${prog} | grep -v ${WRAP_DIR}/${i}-${prog} | head -1\`" >> ${WRAP_DIR}/${i}-${prog}
+		echo "REAL=\"$(which -a ${i}-${prog})\"" >> ${WRAP_DIR}/${i}-${prog}
         echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${i}-${prog}
         echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${i}-${prog}
         echo "export COMPILER_PATH=${WRAP_DIR}/${i}" >> ${WRAP_DIR}/${i}-${prog}
@@ -193,9 +194,9 @@ done
 
 # Faketime for depends so intermediate results are comparable
 export PATH_orig=${PATH}
-create_global_faketime_wrappers "$FAKETIME"
-create_per-host_faketime_wrappers "$FAKETIME"
-create_per-host_linker_wrapper "$FAKETIME"
+create_global_faketime_wrappers "${FAKETIME}"
+create_per-host_faketime_wrappers "${FAKETIME}"
+create_per-host_linker_wrapper "${FAKETIME}"
 export PATH=${WRAP_DIR}:${PATH}
 
 

--- a/contrib/gitian-descriptors/main-build/galaxy-windows.yml
+++ b/contrib/gitian-descriptors/main-build/galaxy-windows.yml
@@ -10,6 +10,7 @@ packages:
 - "g++-5"
 - "mingw-w64"
 - "g++-mingw-w64"
+- "mingw-w64-tools"
 - "cmake"
 - "autoconf"
 - "automake"
@@ -20,6 +21,7 @@ packages:
 - "zlib1g-dev" # for nsis build -- unclear why it is needed  bug(GALAXY-226)
 - "ca-certificates"  #  because of: Problem with the SSL CA cert (path? access rights?)
 - "faketime" # used to force date
+- "zip"
 - "gettext-base" # some scripts/tools used in build could be using gettext translations
 - "gettext" # for msgfmt and other advanced tools to compile language .po to .mo
 reference_datetime: "2016-08-01 00:00:00"

--- a/contrib/nsis-installer-windows/galaxy-windows-installer
+++ b/contrib/nsis-installer-windows/galaxy-windows-installer
@@ -54,6 +54,11 @@ pushd nsis || fail
 
 	export PATH="${HOME}/wrapped:${PATH}"
 
+	# for scons nsis_version - work because we only need day precision
+	# ** more than 24h build of nsis could ruin deteministic
+	export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1
+	export FAKETIME="2016-08-01 00:00:00"
+
 	sed -i '46a\    '$WRAP_DIR'/i686-w64-mingw32-' SCons/Tools/crossmingw.py # add our wrapped i686-w64-mingw32 at the top of compiler available list
 
 	scons UNICODE=yes ZLIB_W32=../zlib PREFIX=install_dir install || fail "Scons failed (of zlib, for NSIS)"

--- a/contrib/nsis-installer-windows/galaxy-windows-installer
+++ b/contrib/nsis-installer-windows/galaxy-windows-installer
@@ -52,6 +52,8 @@ git clone https://github.com/kichik/nsis || fail "clone NSIS"
 pushd nsis || fail
 	git checkout 430d70ce926f96949f424244c31297b5b678165e || fail "Checkout" # version with i686-w64-mingw32, waiting for v30 release
 
+	export PATH="${HOME}/wrapped:${PATH}"
+
 	sed -i '46a\    '$WRAP_DIR'/i686-w64-mingw32-' SCons/Tools/crossmingw.py # add our wrapped i686-w64-mingw32 at the top of compiler available list
 
 	scons UNICODE=yes ZLIB_W32=../zlib PREFIX=install_dir install || fail "Scons failed (of zlib, for NSIS)"


### PR DESCRIPTION
Biggest change was simplify wrappers:
"REAL=\`which -a ${prog} | grep -v ${WRAP_DIR}/${prog} | head -1\`"
to
"REAL=\"$(which -a ${prog})\""

This allow to add dir with wrapper progs to PATH variable (before 'which' command was executed in wrapped prog body, and cause recursive calls).

I fail to force scons using wrapped gcc, I realized also that in perfect situation we should also wrap python that is used by scons.
Nonetheless add LD_PRELOAD and FAKETIME global before scons starts build it is enough for our needs