### PR TITLE
Disabled old node removal ; Doc changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,14 +2,17 @@
 
 ### Version v0.3.1b (pre-alpha)
 
-* Important changes for all users:
+* Important changes:
   * Fixed segfault (nullptr deref) when peered peer with wrong ipv6 (remote attack: crash)
+  * Fixed segfault (nullptr deref) in some cases (from the statistics code) [in rc4].
   * Basic firewall: packets other then UDP/TCP/ICMP are possibly dropped.
   * Node2Node protocol format change (git-rev 456bf77dffd4),
     * Therefore all nodes should update (older nodes are not supported),
   * NAT traversal fixed: same external node can be used from hidden behind one NAT group of several nodes.
+* Changes:
+  * IP change fixed: when one peer changes IP address then we write to him on the new one (e.g. laptop changes WiFi to eth other subnet of same LAN) [in rc4][DISABLED NOW].
 * For users of official binary distribution:
-  * All users:
+  * All systems:
     * Changed default RPC port to 9043 TCP.
   * Windows users:
     * Fixed crash (sometimes) after wake up from sleep.
@@ -21,7 +24,8 @@
   * Linux users:
     * Fixed determinism of Gitian tar/gzip of linux build (perhaps it was not, even though the files inside were).
   * Mac OS X users:
-    * Gitian for Mac OS X - produces deterministic binary. (Still TODO automatic generation of .dmg file itself).
+    * Gitian for Mac OS X - produces deterministic binary.
+    * Gitian for Mac OS X now generates the .dmg though this new functionality is not yet tested [in rc4].
 * Misc:
   * Precompiled headers (with Cotire for CMake) for build speed (tested on Linux, MSVC).
   * Using Jenkins to help with QA of Gitian.

--- a/src/g42-main.cpp
+++ b/src/g42-main.cpp
@@ -284,7 +284,13 @@ int main(int argc, char **argv) {
 
 	using std::cerr; using std::endl;
 
-	_fact( "Start... " );
+	ostringstream oss; oss << "ver. "
+		<< project_version_number_major << "."
+		<< project_version_number_minor << "."
+		<< project_version_number_sub << "."
+		<< project_version_number_patch ;
+	string ver_str = oss.str();
+	_fact( "Start... " << ver_str );
 	string install_dir_base; // here we will find main dir like "/usr/" that contains our share dir
 
 	{

--- a/src/project.hpp
+++ b/src/project.hpp
@@ -67,3 +67,8 @@ class invalid_argument_in_version : public std::invalid_argument {
 
 std::string project_version_info();
 
+constexpr int  project_version_number_major =  0 ;
+constexpr int  project_version_number_minor =  3 ;
+constexpr int  project_version_number_sub   =  1 ;
+constexpr char project_version_number_patch = 'b';
+

--- a/src/tunserver.cpp
+++ b/src/tunserver.cpp
@@ -705,19 +705,24 @@ void c_tunserver::peering_ping_all_peers() {
 	std::lock_guard<std::mutex> lg(m_peer_mutex);
 	auto now = std::chrono::steady_clock::now();
 	_dbg2("Remove inactive peers, time="<<now);
+	bool enable_remove=false; // if false then just count, do not remove
 	size_t count_removed=0; // how many we removed
 	for (auto it = m_peer.begin(); it != m_peer.end();) {
 		auto last_ping_seconds = std::chrono::duration_cast<std::chrono::seconds>(now - it->second->get_last_ping_time()); //< seconds after the last
 		if (last_ping_seconds > std::chrono::seconds(30)) { // TODO configure this
 			_note("removing peer " << it->first.get_hip_as_string(true));
 			++count_removed;
-			m_peer.erase(it++);
+			if (enable_remove) m_peer.erase(it);
+			++ it;
 		} else {
 			++ it;
 		}
 
 	}
-	if (count_removed) _mark("Removed " << count_removed << " inactive peer(s), time="<<now);
+	if (count_removed) {
+		_mark( (enable_remove ? "Removed actually" : "Would remove (but disabled)")
+		<< count_removed << " inactive peer(s), time="<<now);
+	}
 
 	_info("Sending ping to all peers (count=" << m_peer.size() << ")");
 	for(auto & v : m_peer) { // to each peer


### PR DESCRIPTION
Do we really need to remove old nodes?

If they have new IP then there is code there to replace the physical IP of existing node, it should just get updated if it's same peer as in same ipv6-galaxy.

Downside is that we stop trying to (re)connect to peers that were down for some time.
@robertoleksy 

Updated changelog.