### PR TITLE
fix unittest of wrap_thread  because the code was not always failing :) includes fix for make run directory

### DIFF
--- a/rundevel.sh
+++ b/rundevel.sh
@@ -4,7 +4,7 @@ echo "=============================================================="
 echo "rundevel - Run for Developer"
 echo "=============================================================="
 
-program_bin="./Debug/tunserver.elf"
+program_bin="./tunserver.elf"
 
 [[ -r "$program_bin" ]] || {
 	echo "Can not find binary ($program_bin) - try entering directory build/ first, or doing ./do if you do not have that";

--- a/src/test/utils_wrap_thread.cpp
+++ b/src/test/utils_wrap_thread.cpp
@@ -15,7 +15,6 @@ TEST(utils_wrap_thread, simple_thread_replace) {
 }
 
 TEST(utils_wrap_thread, thread_at_throws_in_middle_of_move) {
-	g_dbg_level_set(10,"test");
 
 	std::vector<wrap_thread> vec;
 	vec.resize(1);
@@ -25,7 +24,7 @@ TEST(utils_wrap_thread, thread_at_throws_in_middle_of_move) {
 	// in the temporary - we would have created std::thread( {some..work..in..lanbda} )
 	// and the thread would keep running since the exception would end function before thread is joined
 	std::atomic<bool> endflag{false};
-	_mark("Thread ...");
+	_info("Thread will start now");
 
 	auto example_function_causing_abort = [&]() {
 		_info("Starting the bad function that should crash (abort)");
@@ -38,15 +37,15 @@ TEST(utils_wrap_thread, thread_at_throws_in_middle_of_move) {
 			} );
 			vec.at(1) = std::move(mythread) ;
 			_erro("This code should not be reached (above the function at() should throw");
-			bool joined = vec.at(1).try_join( std::chrono::seconds(5) ); // trying to join for 1 second
+			bool joined = vec.at(1).try_join( std::chrono::seconds(5) ); // trying to join for few seconds
 			_erro("This unreachable code, has joined=" << joined);
 		}
 		catch(const std::out_of_range &) {
 			_erro("As expected, the code thrown... though we will not reach this place here, since the destructor of now detached thread will abort program.");
-	//		EXPECT_FALSE(true);
+			FAIL(); // unreachable
 		}
 		_erro("Should not reach this place");
-	//	EXPECT_FALSE(true);
+		FAIL(); // unreachable
 	};
 
 	EXPECT_DEATH( { example_function_causing_abort(); } , ""); // catch std::abort

--- a/src/utils/wrap_thread.cpp
+++ b/src/utils/wrap_thread.cpp
@@ -69,22 +69,25 @@ bool wrap_thread::try_join(std::chrono::duration<double> duration) {
 }
 
 wrap_thread::~wrap_thread()  {
-
 	m_time_stopped = t_sysclock::now();
-	_info(info());
+	_info("wrap_thread destructor." + info());
 
-	if(!m_future.valid())
+	if(!m_future.valid()) {
+		_info("wrap_thread destructor - nothing to do (it was joined already?)"); // XXX more comments
 		return;
+	}
 
 	if (m_destroy_timeout != std::chrono::seconds(0)) {
+		_info("wrap_thread destructor - will try to join it automatically, for time: " << m_destroy_timeout.count());
 		std::future_status status = m_future.wait_for(m_destroy_timeout);
 		if (status != std::future_status::ready) {
-			_erro("can not end thread in given time");
+			_erro("can not end thread in given time. Will abort now.");
 			std::abort();
 		}
-		m_future.get();
+		_erro("thread was correctly joined it seems");
+		m_future.get(); // why? XXX
 	} else {
-		_erro("This thread was not joined!");
+		_erro("This thread was not joined, and you set to not wait for joining. Will abort.");
 		std::abort();
 	}
 }

--- a/src/utils/wrap_thread.cpp
+++ b/src/utils/wrap_thread.cpp
@@ -84,7 +84,7 @@ wrap_thread::~wrap_thread()  {
 			_erro("can not end thread in given time. Will abort now.");
 			std::abort();
 		}
-		_erro("thread was correctly joined it seems");
+		_info("thread was correctly joined it seems");
 		m_future.get(); // why? XXX
 	} else {
 		_erro("This thread was not joined, and you set to not wait for joining. Will abort.");


### PR DESCRIPTION
.at() = b()

was sometimes NOT failing, not showing how wrap_thread fixes the UB (not aborting)