### PR TITLE
[gitian] windows build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,8 @@ endif()
 
 if (MSVC)
 	set(BOOST_LIBS_LIST system filesystem thread date_time)
+elseif (MINGW)
+	set(BOOST_LIBS_LIST system filesystem program_options date_time)
 else()
 	set(BOOST_LIBS_LIST system filesystem program_options thread date_time)
 endif()


### PR DESCRIPTION
same as 374aff81e7339d97aa54c412b9d44a871de2dfcf - disappeared during merging
'remove boost thread from BOOST_LIBS_LIST for MINGW build'